### PR TITLE
[fix] correct GitHub Actions workflow to build from root directory

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -16,18 +16,8 @@ jobs:
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
         restore-keys: |
           ${{ runner.os }}-gems-
-    # Standard usage
-    - uses:  helaili/jekyll-action@v2
-      with:
-        token: ${{ secrets.LUODIAN_PAGES }}
 
-    # Specify the Jekyll source location as a parameter
-    - uses: helaili/jekyll-action@v2
-      with:
-        token: ${{ secrets.LUODIAN_PAGES }}
-        jekyll_src: 'docs'
-
-    # Specify the target branch (optional)
+    # Build Jekyll from root directory and deploy to gh-pages
     - uses: helaili/jekyll-action@v2
       with:
         token: ${{ secrets.LUODIAN_PAGES }}


### PR DESCRIPTION
The workflow was incorrectly trying to use 'docs' as Jekyll source, but 'docs' is actually the output destination. Fixed to build from root directory and deploy to gh-pages branch.