### PR TITLE
Trigger build process for SVG changes

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -25,10 +25,16 @@ jobs:
           GITHUB_ORG: ${{ vars.GITHUB_ORG }}
         run: python scripts/update_badges.py
       
-      - name: Commit changes
+      - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.LUODIAN_PAGES }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add assets/img/citations.svg assets/img/github-stars.svg
-          git diff --staged --quiet || git commit -m "chore: update badges"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update badges"
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:${{ github.ref_name }}
+          fi


### PR DESCRIPTION
When using GITHUB_TOKEN, pushes don't trigger other workflows. Switch to LUODIAN_PAGES PAT so badge updates trigger the GitHub Pages build workflow.